### PR TITLE
Fixed wording: AccountName --> OrganizationName

### DIFF
--- a/AzurePipelines/trigger-azure-pipelines.yml
+++ b/AzurePipelines/trigger-azure-pipelines.yml
@@ -40,6 +40,6 @@ jobs:
     - name: 'Trigger an Azure Pipeline to deploy the app to PRODUCTION'
       uses: Azure/pipelines@releases/v1
       with:
-        azure-devops-project-url: 'https://dev.azure.com/AccountName/ProjectName'
+        azure-devops-project-url: 'https://dev.azure.com/OrganizationName/ProjectName'
         azure-pipeline-name: 'WebApp_Azure_Prod' 
         azure-devops-token: '${{ secrets.AZURE_DEVOPS_TOKEN }}'


### PR DESCRIPTION
Changed `AccountName` to `OrganizationName` to reflect the correct naming with Azure DevOps/Pipelines.