### PR TITLE
Add action to set Python version and remove "antenv"

### DIFF
--- a/AppService/python-webapp-on-azure.yml
+++ b/AppService/python-webapp-on-azure.yml
@@ -8,12 +8,18 @@ jobs:
     # checkout the repo
     - uses: actions/checkout@master
     
+    # Set Python version
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.7.x' 
+        architecture: 'x64'
+    
     # install dependencies
     - name: python install
       run: |
         sudo apt install python3.6-venv
-        python3.6 -m venv antenv
-        source antenv/bin/activate
+        python3.6 -m venv env
+        source env/bin/activate
         pip3.6 install setuptools
         pip3.6 install -r requirements.txt
 


### PR DESCRIPTION
The virtual environment should not be called "antenv". If we deploy the virtual env with that name, App Service attempts to use it at runtime. This actually creates problems because the virtual env was built on the GitHub VM using a different Linux distro than what is used on App Service. The Python dependencies will be installed with paths that do not exist on App Service.

Try deploying a Django app with MySQL and "antenv", it won't work because lib-my-sql is in a different location on the App Service Linux distro.