### PR TITLE
Add private registry authentication in web app  container

### DIFF
--- a/AppService/docker-webapp-container-on-azure.yml
+++ b/AppService/docker-webapp-container-on-azure.yml
@@ -38,8 +38,31 @@ jobs:
     - name: Docker Build & Push to ACR
       run: |
         docker build . -t ${{ env.CONTAINER_REGISTRY }}/nodejsapp:${{ github.sha }}
-        docker push ${{ env.CONTAINER_REGISTRY }}/nodejsapp:${{ github.sha }}  
-    - name: 'Deploy to Azure Web App for Container'   
+        docker push ${{ env.CONTAINER_REGISTRY }}/nodejsapp:${{ github.sha }} 
+
+#     - name: Set Web App ACR authentication
+#       uses: Azure/appservice-settings@v1
+#       with:
+#       app-settings-json: |
+#         [
+#             {
+#                 "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
+#                 "value": "${{ secrets.REGISTRY_PASSWORD }}",
+#                 "slotSetting": false
+#             },
+#             {
+#                 "name": "DOCKER_REGISTRY_SERVER_URL",
+#                 "value": "https://${{ env.CONTAINER_REGISTRY }}",
+#                 "slotSetting": false
+#             },
+#             {
+#                 "name": "DOCKER_REGISTRY_SERVER_USERNAME",
+#                 "value": "${{ secrets.REGISTRY_USERNAME  }}",
+#                 "slotSetting": false
+#             }
+#         ]
+
+    - name: 'Deploy to Azure Web App for Container'
       uses: azure/webapps-deploy@v2
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} 


### PR DESCRIPTION
How to authenticate a private registry in a web app for container deployment

If we can't rely on the fact that private registry has been previously set on the web app, this is one way of doing it on the workflow.