### PR TITLE
on CI CD enviroments is suggested restore

### DIFF
--- a/AppService/asp.net-core-webapp-on-azure.yml
+++ b/AppService/asp.net-core-webapp-on-azure.yml
@@ -36,6 +36,7 @@ jobs:
       # Run dotnet build and publish
       - name: dotnet build and publish
         run: |
+          dotnet restore
           dotnet build --configuration Release
           dotnet publish -c Release -o '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/myapp' 
           


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build#implicit-restore

The dotnet restore command is still useful in certain scenarios where explicitly restoring makes sense, such as continuous integration builds in Azure DevOps Services or in build systems that need to explicitly control when the restore occurs.