### PR TITLE
Update java function app templates

### DIFF
--- a/FunctionApp/linux-java-functionapp-on-azure.yml
+++ b/FunctionApp/linux-java-functionapp-on-azure.yml
@@ -33,7 +33,6 @@ jobs:
       run: |
         pushd './${{ env.POM_XML_DIRECTORY }}'
         mvn clean package
-        mvn azure-functions:package
         popd
 
     - name: 'Run Azure Functions Action'

--- a/FunctionApp/windows-java-functionapp-on-azure.yml
+++ b/FunctionApp/windows-java-functionapp-on-azure.yml
@@ -33,7 +33,6 @@ jobs:
       run: |
         pushd './${{ env.POM_XML_DIRECTORY }}'
         mvn clean package
-        mvn azure-functions:package
         popd
 
     - name: 'Run Azure Functions Action'


### PR DESCRIPTION
The java function app no longer requires `mvn azure-functions:package` to generate function artifact.