### PR TITLE
docs: add npm prune step after build

### DIFF
--- a/FunctionApp/linux-node.js-functionapp-on-azure.yml
+++ b/FunctionApp/linux-node.js-functionapp-on-azure.yml
@@ -34,6 +34,7 @@ jobs:
         npm install
         npm run build --if-present
         npm run test --if-present
+        npm prune --production
         popd
 
     - name: 'Run Azure Functions Action'


### PR DESCRIPTION
Running `npm prune --production` after build steps and right before the FA is deployed can reduce the deployment artifact size significantly.