### PR TITLE
Fix python template to use vmImage ubuntu-18.04

### DIFF
--- a/FunctionApp/linux-python-functionapp-on-azure.yml
+++ b/FunctionApp/linux-python-functionapp-on-azure.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@master


### PR DESCRIPTION
We notice an issue when using ubuntu-20.04 or ubuntu-latest will cause the pyodbc package throws the follow errors:
```
Exception while executing function: Functions.Example Result: Failure
Exception: ImportError: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /home/site/wwwroot/.python_packages/lib/site-packages/pyodbc.cpython-38-x86_64-linux-gnu.so)
Stack:   File "/azure-functions-host/workers/python/3.8/LINUX/X64/azure_functions_worker/dispatcher.py", line 355, in _handle__invocation_request
    call_result = await self._loop.run_in_executor(
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/azure-functions-host/workers/python/3.8/LINUX/X64/azure_functions_worker/dispatcher.py", line 542, in __run_sync_func
    return func(**params)
  File "/home/site/wwwroot/Example/__init__.py", line 7, in main
    import pyodbc
```

This is due to the inconsistency between pipeline build agent and runtime environment. By locking the build image to ubuntu-18.04, we can mitigate this issue. Original thread: https://github.com/Azure/static-web-apps/issues/291