### PR TITLE
Fix two runs-on on GH Action sample

### DIFF
--- a/FunctionApp/linux-python-functionapp-on-azure.yml
+++ b/FunctionApp/linux-python-functionapp-on-azure.yml
@@ -19,7 +19,6 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     environment: dev
-    runs-on: ubuntu-18.04
     steps:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@master


### PR DESCRIPTION
There are two runs-on lines which generates a syntax error.
Removing old ubuntu-18.04 which would be deprecated soon in future.