### PR TITLE
Add workflows for Java projects managed by Gradle

### DIFF
--- a/AppService/java-jar-gradle-webapp-on-azure.yml
+++ b/AppService/java-jar-gradle-webapp-on-azure.yml
@@ -1,0 +1,40 @@
+name: Deploy Java Web App to Azure
+
+on:
+  [push,pull_request]
+
+# CONFIGURATION
+# For help, go to https://github.com/Azure/Actions
+#
+# 1. Set up the following secrets in your repository:
+#   AZURE_WEBAPP_PUBLISH_PROFILE
+#
+# 2. Change these variables for your configuration:
+env:
+  AZURE_WEBAPP_NAME: your-app-name # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: ${{ github.workspace }} # set this to the path to your web app project
+  JAVA_VERSION: '11'                # set this to the Java version to use
+  AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}     # set GH repo secret with the publish profile of the web app
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+    - name: Build with Gradle 
+      run: ./gradlew bootJar
+    - name: 'Deploy to Azure WebApp'
+      uses: azure/webapps-deploy@v2
+      with: 
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
+        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/libs/*.jar'
+        
+  # For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
+  # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/AppService/java-war-gradle-webapp-on-azure.yml
+++ b/AppService/java-war-gradle-webapp-on-azure.yml
@@ -1,0 +1,43 @@
+name: Deploy Java War package to Azure web app
+
+on:
+  [push,pull_request]
+
+# CONFIGURATION
+# For help, go to https://github.com/Azure/Actions
+#
+# 1. Set up the following secrets in your repository:
+#   AZURE_WEBAPP_PUBLISH_PROFILE
+#
+# 2. Change these variables for your configuration:
+env:
+  AZURE_WEBAPP_NAME: your-app-name # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: ${{ github.workspace }} # set this to the path to your web app project
+  JAVA_VERSION: '11'                # set this to the java version to use
+  AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}     # set GH repo secret with the publish profile of the web app
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+    - name: Build with Gradle
+      run: ./gradlew build
+    # Optional: rename the WAR to ROOT.war
+    # see more at https://docs.microsoft.com/en-us/answers/questions/818821/
+    # - name: Rename to ROOT
+    #   run: mv '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/lib/*.war' '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/libs/ROOT.war'
+    - name: 'Deploy to Azure WebApp'
+      uses: azure/webapps-deploy@v2
+      with: 
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
+        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/lib/*.war'
+        
+  # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/AppService/java-war-gradle-webapp-on-azure.yml
+++ b/AppService/java-war-gradle-webapp-on-azure.yml
@@ -38,6 +38,6 @@ jobs:
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/lib/*.war'
+        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/libs/*.war'
         
   # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples


### PR DESCRIPTION
Nowadays, more and more developers would choose `Gradle` as the build tool for their web projects (e.g., #102).

As a result, I added two workflows based on `Gradle`, and the main configuration is the same as its  `Maven` counterpart.

As for `jar` deployment (e.g., Spring boot application):

```yaml
    - name: Build with Gradle 
      run: ./gradlew bootJar
    - name: 'Deploy to Azure WebApp'
      uses: azure/webapps-deploy@v2
      with: 
        app-name: ${{ env.AZURE_WEBAPP_NAME }}
        publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/libs/*.jar'
```

As for `war` deployment (e.g., for Tomcat):

```yaml
    - name: Build with Gradle
      run: ./gradlew build
    - name: 'Deploy to Azure WebApp'
      uses: azure/webapps-deploy@v2
      with: 
        app-name: ${{ env.AZURE_WEBAPP_NAME }}
        publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
        package: '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/build/libs/*.war'
```