### PR TITLE
Fix `name` key placement in `python-webapp-on-azure.yml`

### DIFF
--- a/AppService/python-webapp-on-azure.yml
+++ b/AppService/python-webapp-on-azure.yml
@@ -17,9 +17,9 @@ env:
   PYTHON_VERSION: '3.7' 
   STARTUP_COMMAND: ''           # set this to the startup command required to start the gunicorn server. default it is empty
 
-name: Build and deploy Python app
 jobs:
  build-and-deploy:
+  name: Build and deploy Python app
   runs-on: ubuntu-latest
   environment: dev
   steps:


### PR DESCRIPTION
The name associated with the `build-and-deploy` job was defined outside of the `jobs` section.