### PR TITLE
Removing extra "name:" in the top level python.yml

### DIFF
--- a/AppService/python-webapp-on-azure.yml
+++ b/AppService/python-webapp-on-azure.yml
@@ -17,7 +17,6 @@ env:
   PYTHON_VERSION: '3.7' 
   STARTUP_COMMAND: ''           # set this to the startup command required to start the gunicorn server. default it is empty
 
-name: Build and deploy Python app
 jobs:
  build-and-deploy:
   runs-on: ubuntu-latest


### PR DESCRIPTION
Correct syntax error due to multiple name tags in the top level of python.yml