### PR TITLE
Update to latest action versions

### DIFF
--- a/AppService/asp.net-core-webapp-on-azure.yml
+++ b/AppService/asp.net-core-webapp-on-azure.yml
@@ -17,7 +17,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: '2.2.402'           # set this to the dot net version to use
+  DOTNET_VERSION: '3.1.x'             # set this to the dot net version to use
 
 jobs:
   build-and-deploy:
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       # Checkout the repo
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       
       # Setup .NET Core SDK
       - name: Setup .NET Core

--- a/AppService/asp.net-core-webapp-on-azure.yml
+++ b/AppService/asp.net-core-webapp-on-azure.yml
@@ -17,7 +17,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: '3.1.x'             # set this to the dot net version to use
+  DOTNET_VERSION: '7.0.x'             # set this to the dot net version to use
 
 jobs:
   build-and-deploy:

--- a/AppService/asp.net-webapp-on-azure.yml
+++ b/AppService/asp.net-webapp-on-azure.yml
@@ -17,7 +17,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NUGET_VERSION: '5.3.1'           # set this to the dot net version to use
+  NUGET_VERSION: '5.3.x'              # set this to the dot net version to use
 
 jobs:
   build-and-deploy:
@@ -26,7 +26,7 @@ jobs:
     steps:
 
     # checkout the repo
-    - uses: actions/checkout@master  
+    - uses: actions/checkout@v3  
     
     - name: Install Nuget
       uses: nuget/setup-nuget@v1

--- a/AppService/docker-asp.net-core-webapp-sql-on-azure.yaml
+++ b/AppService/docker-asp.net-core-webapp-sql-on-azure.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Login for az cli commands 
       uses: azure/login@v1
@@ -71,7 +71,7 @@ jobs:
     environment: test
     steps:
     - name: Checkout Source Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Login for az cli commands 
       uses: azure/login@v1

--- a/AppService/docker-webapp-container-on-azure.yml
+++ b/AppService/docker-webapp-container-on-azure.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Azure authentication
       uses: azure/login@v1
       with:

--- a/AppService/go-webapp-on-azure.yml
+++ b/AppService/go-webapp-on-azure.yml
@@ -21,7 +21,7 @@ jobs:
   environment: production
   steps:
   # checkout the repo 
-  - uses: actions/checkout@master
+  - uses: actions/checkout@v3
   # setup Go
   - name: Setup Go
     uses: actions/setup-go@v3

--- a/AppService/java-jar-webapp-on-azure.yml
+++ b/AppService/java-jar-webapp-on-azure.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/AppService/java-war-webapp-on-azure.yml
+++ b/AppService/java-war-webapp-on-azure.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/AppService/node.js-webapp-on-azure.yml
+++ b/AppService/node.js-webapp-on-azure.yml
@@ -13,7 +13,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: '10.x'                # set this to the node version to use
+  NODE_VERSION: '16.x'                # set this to the node version to use
 
 jobs:
   build-and-deploy:
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: npm install, build, and test

--- a/AppService/node_express_sampleApp/.github/workflows/workflow.yml
+++ b/AppService/node_express_sampleApp/.github/workflows/workflow.yml
@@ -13,18 +13,18 @@ on:
       - master
 
 env:
-  AZURE_WEBAPP_NAME: nodeappgh   # set this to your application's name
+  AZURE_WEBAPP_NAME: nodeappgh        # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: '10.x'                # set this to the node version to use
+  NODE_VERSION: '16.x'                # set this to the node version to use
 
 jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: npm install, build, and test
@@ -35,7 +35,7 @@ jobs:
         npm run build --if-present
         npm run test --if-present
     - name: 'Deploy to Azure WebApp'
-      uses: azure/webapps-deploy@v1
+      uses: azure/webapps-deploy@v2
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}

--- a/AppService/php-webapp-on-azure.yml
+++ b/AppService/php-webapp-on-azure.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: 'Deploy to Azure WebApp'
       uses: azure/webapps-deploy@v2

--- a/AppService/python-webapp-on-azure.yml
+++ b/AppService/python-webapp-on-azure.yml
@@ -24,7 +24,7 @@ jobs:
   environment: dev
   steps:
   # checkout the repo 
-  - uses: actions/checkout@master
+  - uses: actions/checkout@v3
   # setup python
   - name: Setup Python
     uses: actions/setup-python@v1

--- a/AppService/python-webapp-on-azure.yml
+++ b/AppService/python-webapp-on-azure.yml
@@ -12,9 +12,9 @@ on:
 #
 # 2. Change these variables for your configuration:
 env:
-  AZURE_WEBAPP_NAME: Python-thecatsaidno # set this to your application's name
-  WORKING_DIRECTORY: '.'         # set this to the path to your path of working directory inside github repository, defaults to the repository root
-  PYTHON_VERSION: '3.7' 
+  AZURE_WEBAPP_NAME: my-app     # set this to your application's name
+  WORKING_DIRECTORY: '.'        # set this to the path to your path of working directory inside github repository, defaults to the repository root
+  PYTHON_VERSION: '3.10'        # set the version to use
   STARTUP_COMMAND: ''           # set this to the startup command required to start the gunicorn server. default it is empty
 
 name: Build and deploy Python app


### PR DESCRIPTION
GH actions gives warning The following actions uses node12 which is deprecated and will be forced to run on node16 due to the usage of older versions of GH actions in our workflow files. Upgrading the package `@actions/checkout` to v3(newer version). 
Reference: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Workflow with older version of action/checkout: https://github.com/sgollapudi77/nodeJsExpressHelloworld/actions/runs/6276548930
![Screenshot (147)](https://github.com/Azure/actions-workflow-samples/assets/85578033/50b6c05f-ca24-476e-93fe-521ef80948d2)

Workflow with latest action: https://github.com/sgollapudi77/nodeJsExpressHelloworld/actions/runs/6296899297

![Screenshot (148)](https://github.com/Azure/actions-workflow-samples/assets/85578033/c4c770fb-c07f-4309-9f6c-203567649e31)
