### PR TITLE
Commenting `npm run test` in the sample workflow

### DIFF
--- a/AppService/node_express_sampleApp/.github/workflows/workflow.yml
+++ b/AppService/node_express_sampleApp/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
         # deploy to Azure Web App.
         npm install
         npm run build --if-present
-        npm run test --if-present
+        # npm run test --if-present
     - name: 'Deploy to Azure WebApp'
       uses: azure/webapps-deploy@v2
       with: 


### PR DESCRIPTION
Commenting the `npm run test`. 
Changing the template for nodejs.yml for webdeploy action. By default, the test gets executed and it takes longer time to complete the action. Commenting out so that by default behavior is fast and user can uncomment if they choose to run the tests.