### PR TITLE
Update windows-dotnet-functionapp-on-azure.yml

### DIFF
--- a/FunctionApp/windows-dotnet-functionapp-on-azure.yml
+++ b/FunctionApp/windows-dotnet-functionapp-on-azure.yml
@@ -32,7 +32,7 @@ jobs:
       shell: pwsh
       run: |
         pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-        dotnet build --configuration Release --output ./output
+        dotnet build --configuration Release --property:OutputPath=./output
         popd
 
     - name: 'Run Azure Functions Action'


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid

This helps get rid of the warning soon to be error in .net 7

<img width="1306" alt="image" src="https://github.com/Azure/actions-workflow-samples/assets/695710/c10c62e4-8316-43ac-af5f-edd6d50f528e">
