### PR TITLE
Refresh oidc-auth-samples: bump action versions and runtime versions

### DIFF
--- a/FunctionApp/oidc-auth-samples/linux-dotnet-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/linux-dotnet-functionapp-on-azure-oidc.yml
@@ -29,7 +29,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: 'APP_NAME'         # Set this to your function app name on Azure 
   AZURE_FUNCTIONAPP_PROJECT_PATH: '.'        # Set this to the path to your function app project, defaults to the repository root. The deploy action will package the contents of this path.
-  DOTNET_VERSION: '9.0.x'                    # Set this to the .NET version of your project
+  DOTNET_VERSION: '10.0.x'                   # Set this to the .NET version of your project
   BUILD_ARTIFACT_NAME: 'released-package'    # Set this according to your team's naming convention
   
 jobs:
@@ -44,10 +44,10 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up .NET version: ${{ env.DOTNET_VERSION }}'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -57,7 +57,7 @@ jobs:
         run: dotnet publish --configuration Release --output ./output
 
       - name: Upload artifact for the deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/output
@@ -70,13 +70,13 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -87,6 +87,6 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/linux-java-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/linux-java-functionapp-on-azure-oidc.yml
@@ -27,7 +27,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: 'APP_NAME'          # set this to your function app name on Azure. Ensure that `functionAppName` in your pom.xml file matches. 
   POM_XML_DIRECTORY: '.'                      # set this to the directory which contains the pom.xml file. The deploy action will package the contents of this path.
-  JAVA_VERSION: '17'                          # set this to the Java version of your project
+  JAVA_VERSION: '21'                          # set this to the Java version of your project
   BUILD_ARTIFACT_NAME: 'released-package'     # Set this according to your team's naming convention
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         working-directory: ${{ env.POM_XML_DIRECTORY }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up Java version: ${{ env.JAVA_VERSION }}'
         uses: actions/setup-java@v4
@@ -51,12 +51,12 @@ jobs:
           distribution: 'microsoft'
 
       - name: 'Build project with Maven'
-        run: mvn clean package
+        run: mvn clean package -DfunctionAppName=${{ env.AZURE_FUNCTIONAPP_NAME }}
 
       # Perform additional steps such as running tests, if needed
       
       - name: 'Upload artifact for the deployment job'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.POM_XML_DIRECTORY }}/target/azure-functions/${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -68,13 +68,13 @@ jobs:
       id-token: write  # Required to fetch an OIDC token to authenticate with the job
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.POM_XML_DIRECTORY }}/downloaded-artifact'
       
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -85,7 +85,7 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.POM_XML_DIRECTORY }}/downloaded-artifact'
           respect-pom-xml: false # Set to `true` if the build artifact path is ${{ env.POM_XML_DIRECTORY }}
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/linux-node-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/linux-node-functionapp-on-azure-oidc.yml
@@ -42,10 +42,10 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up Node version: ${{ env.NODE_VERSION }}'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -62,7 +62,7 @@ jobs:
         run: npm prune --production
       
       - name: 'Upload artifact for the deployment job'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
@@ -74,13 +74,13 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -91,6 +91,6 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/powershell-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/powershell-functionapp-on-azure-oidc.yml
@@ -37,12 +37,12 @@ jobs:
       contents: read   # Required for actions/checkout
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Perform additional steps such as running tests, if needed
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/FunctionApp/oidc-auth-samples/python-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/python-functionapp-on-azure-oidc.yml
@@ -27,7 +27,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: 'APP_NAME'        # Set this to your function app name on Azure 
   AZURE_FUNCTIONAPP_PROJECT_PATH: '.'       # Set this to the path to your function app project, defaults to the repository root. The deploy action will package the contents of this path.
-  PYTHON_VERSION: '3.12.x'                  # Set this to the Python version of your project
+  PYTHON_VERSION: '3.13.x'                  # Set this to the Python version of your project
   BUILD_ARTIFACT_NAME: 'released-package'   # Set this according to your team's naming convention
   
 jobs:
@@ -42,10 +42,10 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: 'Set up Python version: ${{ env.Python_VERSION }}'
-        uses: actions/setup-python@v5
+      - name: 'Set up Python version: ${{ env.PYTHON_VERSION }}'
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -55,7 +55,7 @@ jobs:
       # Perform additional steps such as running tests, if needed
 
       - name: 'Upload artifact for the deployment job'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
@@ -67,13 +67,13 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -84,6 +84,6 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/windows-dotnet-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/windows-dotnet-functionapp-on-azure-oidc.yml
@@ -29,7 +29,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: 'APP_NAME'         # Set this to your function app name on Azure 
   AZURE_FUNCTIONAPP_PROJECT_PATH: '.'        # Set this to the path to your function app project, defaults to the repository root. The deploy action will package the contents of this path.
-  DOTNET_VERSION: '9.0.x'                    # Set this to the .NET version of your project
+  DOTNET_VERSION: '10.0.x'                   # Set this to the .NET version of your project
   BUILD_ARTIFACT_NAME: 'released-package'    # Set this according to your team's naming convention
   
 jobs:
@@ -44,10 +44,10 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up .NET version: ${{ env.DOTNET_VERSION }}'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -57,7 +57,7 @@ jobs:
         run: dotnet publish --configuration Release --output ./output
 
       - name: Upload artifact for the deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/output
@@ -70,13 +70,13 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -87,6 +87,6 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/windows-java-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/windows-java-functionapp-on-azure-oidc.yml
@@ -27,7 +27,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: 'APP_NAME'          # set this to your function app name on Azure. Ensure that `functionAppName` in your pom.xml file matches. 
   POM_XML_DIRECTORY: '.'                      # set this to the directory which contains the pom.xml file. The deploy action will package the contents of this path.
-  JAVA_VERSION: '17'                          # set this to the Java version of your project
+  JAVA_VERSION: '21'                          # set this to the Java version of your project
   BUILD_ARTIFACT_NAME: 'released-package'     # Set this according to your team's naming convention
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         working-directory: ${{ env.POM_XML_DIRECTORY }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up Java version: ${{ env.JAVA_VERSION }}'
         uses: actions/setup-java@v4
@@ -51,12 +51,12 @@ jobs:
           distribution: 'microsoft'
 
       - name: 'Build project with Maven'
-        run: mvn clean package
+        run: mvn clean package -DfunctionAppName=${{ env.AZURE_FUNCTIONAPP_NAME }}
 
       # Perform additional steps such as running tests, if needed
       
       - name: 'Upload artifact for the deployment job'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.POM_XML_DIRECTORY }}/target/azure-functions/${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -68,13 +68,13 @@ jobs:
       id-token: write  # Required to fetch an OIDC token to authenticate with the job
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.POM_XML_DIRECTORY }}/downloaded-artifact'
       
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -85,7 +85,7 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.POM_XML_DIRECTORY }}/downloaded-artifact'
           respect-pom-xml: false # Set to `true` if the build artifact path is ${{ env.POM_XML_DIRECTORY }}
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/FunctionApp/oidc-auth-samples/windows-node-functionapp-on-azure-oidc.yml
+++ b/FunctionApp/oidc-auth-samples/windows-node-functionapp-on-azure-oidc.yml
@@ -32,7 +32,7 @@ env:
   
 jobs:
   build:
-    runs-on: windows-latest # Assumes your target function app is Linux-based
+    runs-on: windows-latest # Assumes your target function app is Windows-based
     permissions:
       id-token: write  # Required for OIDC
       contents: read   # Required for actions/checkout
@@ -42,10 +42,10 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Set up Node version: ${{ env.NODE_VERSION }}'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -62,25 +62,25 @@ jobs:
         run: npm prune --production
       
       - name: 'Upload artifact for the deployment job'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: ${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}
   
   deploy:
-    runs-on: windows-latest # Assumes your target function app is Linux-based
+    runs-on: windows-latest # Assumes your target function app is Windows-based
     needs: build
     permissions:
       id-token: write  # Required for OIDC
     steps:
       - name: 'Download artifact from build job'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: ./downloaded-artifact
+          path: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
      
       - name: 'Log in to Azure with AZ CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -91,6 +91,6 @@ jobs:
         id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./downloaded-artifact
+          package: '${{ env.AZURE_FUNCTIONAPP_PROJECT_PATH }}/downloaded-artifact'
 
 # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples


### PR DESCRIPTION
- actions/checkout: v4 -> v6
- actions/setup-dotnet: v4 -> v5
- actions/setup-node: v4 -> v6
- actions/upload-artifact: v4/v6 -> v7
- actions/download-artifact: v4/v7 -> v8
- azure/login: v2 -> v3
- .NET runtime: 9.0.x -> 10.0.x
- Python runtime: 3.12.x -> 3.13.x
- Java runtime: 17 -> 21
- Align artifact download/package paths to use env var
- Add -DfunctionAppName to Maven build command (Java)